### PR TITLE
enclose the flag in backticks to get monospace formatting in discord

### DIFF
--- a/commands/share.go
+++ b/commands/share.go
@@ -56,8 +56,8 @@ func Share(args []string) {
 
 	gistUrl := ""
 	if len(files) > 0 {
-		gistUrl = util.Gist(files)
+		gistUrl = "**" + util.Gist(files) + "**"
 	}
 
-	Chat([]string{fmt.Sprintf("🏁 %s\n**%s**", flag, gistUrl)})
+	Chat([]string{fmt.Sprintf("🏁 `%s`\n%s", flag, gistUrl)})
 }


### PR DESCRIPTION
also only use bold formating for non-zero-length-gist url

fixes: https://github.com/rerrorctf/ret/issues/201